### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MCP Server for Ticketmaster
+[![smithery badge](https://smithery.ai/badge/mcp-server-ticketmaster)](https://smithery.ai/server/mcp-server-ticketmaster)
 
 A Model Context Protocol server that provides tools for discovering events, venues, and attractions through the Ticketmaster Discovery API.
 
@@ -25,6 +26,15 @@ A Model Context Protocol server that provides tools for discovering events, venu
 
 ## Installation
 
+### Installing via Smithery
+
+To install mcp-server-ticketmaster for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-server-ticketmaster):
+
+```bash
+npx -y @smithery/cli install mcp-server-ticketmaster --client claude
+```
+
+### Manual Installation
 ```bash
 npm install mcp-server-ticketmaster
 ```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install mcp-server-ticketmaster for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-server-ticketmaster

Let me know if any tweaks have to be made!